### PR TITLE
fix(FEV-1656): focus border on the dropdown should appear only when using the keyboard to navigate

### DIFF
--- a/src/components/moderation/moderation.scss
+++ b/src/components/moderation/moderation.scss
@@ -56,9 +56,6 @@
       background: initial;
       color: white;
       border: none;
-      &:focus {
-        outline: 1px solid $primary-color;
-      }
       .select {
         font-size: 16px;
         line-height: 21px;


### PR DESCRIPTION
**the issue:**
when clicking the dropdown button using the mouse, the focus border appears. the focus border should appear only when focusing the dropdown button using keyboard navigation (a11y).

**solution:**
remove focus style from dropdown button.

Solves FEV-1656