### PR TITLE
fix(SUP-39294): Page refreshes after clicking on player buttons

### DIFF
--- a/src/components/plugin-button/plugin-button.tsx
+++ b/src/components/plugin-button/plugin-button.tsx
@@ -16,7 +16,7 @@ interface PluginButtonProps {
 export const PluginButton = withText(translates)(({label}: PluginButtonProps) => {
   return (
     <Tooltip label={label} type="bottom">
-        <button aria-label={label} className={ui.style.upperBarIcon} data-testid="moderationPluginButton">
+        <button type="button" aria-label={label} className={ui.style.upperBarIcon} data-testid="moderationPluginButton">
           <Icon
             id="moderation-plugin-button"
             height={icons.BigSize}


### PR DESCRIPTION
**issue:**
When embed player in a form element and click on the plugin button, the page refreshes.

**solution:**
add type=button on the plugin button

solves [SUP-39294](https://kaltura.atlassian.net/browse/SUP-39294)

[SUP-39294]: https://kaltura.atlassian.net/browse/SUP-39294?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ