### PR TITLE
fix(ADA-102): 'Choose a reason for reporting this content’ is not marked as required

### DIFF
--- a/src/components/moderation/moderation.tsx
+++ b/src/components/moderation/moderation.tsx
@@ -152,6 +152,7 @@ export class Moderation extends Component<MergedProps, ModerationState> {
                   ref={node => {
                     this._buttonRef = node;
                   }}
+                  aria-required="true"
                   data-testid="selectButton">
                   <div className={styles.select}>{reportContentType > -1 ? this._getContentType()?.label || '' : this.props.defaultContentType}</div>
                   <div className={styles.downArrow}>


### PR DESCRIPTION
**issue:**
'Choose a reason for reporting this content’ is not marked as required

**solution:**
Adding aria-required


solves [ADA-102](https://kaltura.atlassian.net/browse/ADA-102)

[ADA-102]: https://kaltura.atlassian.net/browse/ADA-102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ