### PR TITLE
fix(ADA-98): Moderation - focus should return to plugin button

### DIFF
--- a/src/components/moderation/moderation.tsx
+++ b/src/components/moderation/moderation.tsx
@@ -29,6 +29,7 @@ interface ModerationProps {
   reportPlaceholder?: string;
   defaultContentType?: string;
   reportTitle?: string;
+  focusButton: () => void;
 }
 
 interface ConnectProps {
@@ -132,7 +133,7 @@ export class Moderation extends Component<MergedProps, ModerationState> {
   };
 
   render(props: MergedProps) {
-    const {playerSize = '', reportLength, subtitle, onClick} = props;
+    const {playerSize = '', reportLength, subtitle, onClick, focusButton} = props;
     const {reportContent, reportContentType, isTextareaActive} = this.state;
     if (playerSize === PLAYER_SIZE.TINY) {
       return null;
@@ -140,7 +141,7 @@ export class Moderation extends Component<MergedProps, ModerationState> {
     const submitButtonDisabled = reportContentType === -1;
     return (
       <OverlayPortal>
-        <Overlay open onClose={onClick}>
+        <Overlay open onClose={onClick} focusButton={focusButton}>
           <div className={[styles.root, styles[playerSize]].join(' ')} data-testid="moderationRoot">
             <div className={styles.mainWrapper}>
               <div className={styles.title}>{this.props.reportTitle}</div>

--- a/src/components/plugin-button/plugin-button.tsx
+++ b/src/components/plugin-button/plugin-button.tsx
@@ -11,12 +11,13 @@ const translates = {
 
 interface PluginButtonProps {
   label?: string;
+  setRef: (ref: HTMLButtonElement | null) => void;
 }
 
-export const PluginButton = withText(translates)(({label}: PluginButtonProps) => {
+export const PluginButton = withText(translates)(({label, setRef}: PluginButtonProps) => {
   return (
     <Tooltip label={label} type="bottom">
-        <button type="button" aria-label={label} className={ui.style.upperBarIcon} data-testid="moderationPluginButton">
+        <button aria-label={label} className={ui.style.upperBarIcon} data-testid="moderationPluginButton" ref={setRef}>
           <Icon
             id="moderation-plugin-button"
             height={icons.BigSize}

--- a/src/moderation-plugin.tsx
+++ b/src/moderation-plugin.tsx
@@ -43,6 +43,7 @@ export class ModerationPlugin extends KalturaPlayer.core.BasePlugin {
   private _removeActiveOverlay: null | Function = null;
   private _pluginIcon = -1;
   private _contribServices: ContribServices;
+  private _pluginButtonRef: HTMLButtonElement | null = null;
 
   constructor(name: string, private _player: KalturaPlayerTypes.Player, config: ModerationPluginConfig) {
     super(name, _player, config);
@@ -127,6 +128,16 @@ export class ModerationPlugin extends KalturaPlayer.core.BasePlugin {
     });
   };
 
+  private _setPluginButtonRef = (ref: HTMLButtonElement) => {
+    this._pluginButtonRef = ref;
+  };
+
+  private _focusPluginButton = () => {
+    setTimeout(() => {
+      this._pluginButtonRef?.focus();
+    },100);
+  };
+
   private _toggleOverlay = (event?: OnClickEvent, byKeyboard?: boolean) => {
     if (this._removeActiveOverlay !== null) {
       this._removeOverlay();
@@ -177,6 +188,7 @@ export class ModerationPlugin extends KalturaPlayer.core.BasePlugin {
           subtitle={subtitle}
           moderateOptions={moderateOptions}
           closeButtonSelected={closeButtonSelected}
+          focusButton={this._focusPluginButton}
         />
       )
     });
@@ -191,7 +203,7 @@ export class ModerationPlugin extends KalturaPlayer.core.BasePlugin {
     this.player.ready().then(() => {
       this._pluginIcon = this.upperBarManager!.add({
         label: 'Moderation',
-        component: () => <PluginButton />,
+        component: () => <PluginButton setRef={this._setPluginButtonRef}/>,
         svgIcon: {path: icons.PLUGIN_ICON, viewBox: `0 0 ${icons.BigSize} ${icons.BigSize}`},
         onClick: this._toggleOverlay
       }) as number;


### PR DESCRIPTION
focus should return to moderation button after close the modal by keyboard.
changes was done also in overlay component here - [#824](https://github.com/kaltura/playkit-js-ui/pull/824)


solves [ADA-98](https://kaltura.atlassian.net/browse/ADA-98)

[ADA-98]: https://kaltura.atlassian.net/browse/ADA-98?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ