### PR TITLE
fix(ADA-105): 'Choose a reason for reporting this content’ toggle button.

### DIFF
--- a/src/components/moderation/moderation.tsx
+++ b/src/components/moderation/moderation.tsx
@@ -161,6 +161,7 @@ export class Moderation extends Component<MergedProps, ModerationState> {
                   }}
                   aria-required="true"
                   aria-expanded={this.state.open}
+                  aria-controls="popoverContent"
                   data-testid="selectButton">
                   <div className={styles.select}>{reportContentType > -1 ? this._getContentType()?.label || '' : this.props.defaultContentType}</div>
                   <div className={styles.downArrow}>

--- a/src/components/moderation/moderation.tsx
+++ b/src/components/moderation/moderation.tsx
@@ -41,12 +41,15 @@ interface ModerationState {
   reportContentType: number;
   reportContent: string;
   isTextareaActive: boolean;
+  open: boolean;
+
 }
 
 const initialState: ModerationState = {
   reportContent: '',
   reportContentType: -1,
-  isTextareaActive: false
+  isTextareaActive: false,
+  open: false
 };
 
 const translates = ({moderateOptions}: ModerationProps) => {
@@ -131,6 +134,10 @@ export class Moderation extends Component<MergedProps, ModerationState> {
     return this.props.moderateOptions.find((moderateOption: ModerateOption) => moderateOption.id === this.state.reportContentType) || {};
   };
 
+  private _togglePopoverMenu = (open: boolean, callback?: () => void) => {
+    callback ? this.setState({open: open}, callback) : this.setState({open: open});
+  };
+
   render(props: MergedProps) {
     const {playerSize = '', reportLength, subtitle, onClick} = props;
     const {reportContent, reportContentType, isTextareaActive} = this.state;
@@ -145,7 +152,7 @@ export class Moderation extends Component<MergedProps, ModerationState> {
             <div className={styles.mainWrapper}>
               <div className={styles.title}>{this.props.reportTitle}</div>
               {subtitle ? <div className={[styles.subtitle].join(' ')}>{subtitle}</div> : null}
-              <Popover options={this._getPopoverMenuOptions()}>
+              <Popover options={this._getPopoverMenuOptions()} setExpandedState={this._togglePopoverMenu} open={this.state.open}>
                 <button
                   className={styles.selectWrapper}
                   tabIndex={0}
@@ -153,6 +160,7 @@ export class Moderation extends Component<MergedProps, ModerationState> {
                     this._buttonRef = node;
                   }}
                   aria-required="true"
+                  aria-expanded={this.state.open}
                   data-testid="selectButton">
                   <div className={styles.select}>{reportContentType > -1 ? this._getContentType()?.label || '' : this.props.defaultContentType}</div>
                   <div className={styles.downArrow}>

--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -12,20 +12,16 @@ export interface PopoverMenuItem {
 interface PopoverProps {
   options: Array<PopoverMenuItem>;
   children: VNode;
-}
-
-interface PopoverState {
+  setExpandedState: (open: boolean, callback?: () => void) => void;
   open: boolean;
 }
 
-export class Popover extends Component<PopoverProps, PopoverState> {
+
+export class Popover extends Component<PopoverProps> {
   private _controlElementRef: HTMLDivElement | null = null;
   private _popoverElementRef: HTMLDivElement | null = null;
   private _optionsRefMap: Map<number, HTMLDivElement | null> = new Map();
 
-  state = {
-    open: false
-  };
 
   componentWillUnmount() {
     this._removeListeners();
@@ -61,7 +57,7 @@ export class Popover extends Component<PopoverProps, PopoverState> {
   };
 
   private _openPopover = (byKeyboard?: boolean) => {
-    this.setState({open: true}, () => {
+    this.props.setExpandedState(true, () => {
       this._addListeners();
       if (byKeyboard) {
         this._getOptionRef(0)?.focus();
@@ -71,11 +67,11 @@ export class Popover extends Component<PopoverProps, PopoverState> {
 
   private _closePopover = () => {
     this._removeListeners();
-    this.setState({open: false});
+    this.props.setExpandedState(false);
   };
 
   private _togglePopover = (e: MouseEvent | KeyboardEvent, byKeyboard?: boolean) => {
-    if (this.state.open) {
+    if (this.props.open) {
       this._closePopover();
     } else {
       this._openPopover(byKeyboard);
@@ -96,7 +92,7 @@ export class Popover extends Component<PopoverProps, PopoverState> {
   };
 
   render(props: PopoverProps) {
-    const {open} = this.state;
+    const {open} = this.props;
     return (
       <div className={styles.popoverContainer}>
         <div

--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -105,6 +105,7 @@ export class Popover extends Component<PopoverProps> {
         {open && (
           <div
             aria-expanded={open}
+            id="popoverContent"
             ref={node => {
               this._popoverElementRef = node;
             }}


### PR DESCRIPTION
**issue:**
when focusing on Choose a reason for reporting this content button there is no indication it's "collapsed" or extended" for screen reader users

**solution:**
moving open state to moderation and add aria-extended attribute on the button

solves [ADA-105](https://kaltura.atlassian.net/browse/ADA-105)

[ADA-105]: https://kaltura.atlassian.net/browse/ADA-105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ