### PR TITLE
fix(FEC-13517): Wrong and inconsistent order of plugins

### DIFF
--- a/src/components/plugin-button/plugin-button.tsx
+++ b/src/components/plugin-button/plugin-button.tsx
@@ -1,6 +1,7 @@
 import {h} from 'preact';
 import {icons} from '../icons';
 import {ui} from '@playkit-js/kaltura-player-js';
+import { pluginName } from "../../index";
 
 const {Tooltip, Icon} = KalturaPlayer.ui.components;
 const {withText, Text} = KalturaPlayer.ui.preacti18n;
@@ -19,7 +20,7 @@ export const PluginButton = withText(translates)(({label, setRef}: PluginButtonP
     <Tooltip label={label} type="bottom">
         <button type="button" aria-label={label} className={ui.style.upperBarIcon} data-testid="moderationPluginButton" ref={setRef}>
           <Icon
-            id="moderation-plugin-button"
+            id={pluginName}
             height={icons.BigSize}
             width={icons.BigSize}
             viewBox={`0 0 ${icons.BigSize} ${icons.BigSize}`}

--- a/src/components/plugin-button/plugin-button.tsx
+++ b/src/components/plugin-button/plugin-button.tsx
@@ -1,7 +1,7 @@
 import {h} from 'preact';
 import {icons} from '../icons';
 import {ui} from '@playkit-js/kaltura-player-js';
-import { pluginName } from "../../index";
+import { pluginName } from "../../moderation-plugin";
 
 const {Tooltip, Icon} = KalturaPlayer.ui.components;
 const {withText, Text} = KalturaPlayer.ui.preacti18n;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import {ModerationPlugin} from './moderation-plugin';
+import { ModerationPlugin, pluginName } from "./moderation-plugin";
 
 declare var __VERSION__: string;
 declare var __NAME__: string;
@@ -9,6 +9,5 @@ const NAME = __NAME__;
 export {ModerationPlugin as Plugin};
 export {VERSION, NAME};
 
-export const pluginName: string = 'playkit-js-moderation';
 
 KalturaPlayer.core.registerPlugin(pluginName, ModerationPlugin);

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,6 @@ const NAME = __NAME__;
 export {ModerationPlugin as Plugin};
 export {VERSION, NAME};
 
-const pluginName: string = 'playkit-js-moderation';
+export const pluginName: string = 'playkit-js-moderation';
 
 KalturaPlayer.core.registerPlugin(pluginName, ModerationPlugin);

--- a/src/moderation-plugin.tsx
+++ b/src/moderation-plugin.tsx
@@ -12,6 +12,7 @@ import {SuccessIcon} from './components/icons/success-icon';
 import {ModerationEvent} from './event';
 // @ts-ignore
 import {FakeEvent} from '@playkit-js/playkit-js';
+import { pluginName } from "./index";
 
 const {ReservedPresetAreas, ReservedPresetNames} = ui;
 const {Text} = ui.preacti18n;
@@ -193,8 +194,13 @@ export class ModerationPlugin extends KalturaPlayer.core.BasePlugin {
       return;
     }
     this.player.ready().then(() => {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
       this._pluginIcon = this.upperBarManager!.add({
-        label: 'Moderation',
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        displayName: 'Moderation',
+        ariaLabel: 'Moderation',
         component: () => <PluginButton setRef={this._setPluginButtonRef} />,
         svgIcon: {path: icons.PLUGIN_ICON, viewBox: `0 0 ${icons.BigSize} ${icons.BigSize}`},
         onClick: this._toggleOverlay

--- a/src/moderation-plugin.tsx
+++ b/src/moderation-plugin.tsx
@@ -10,9 +10,10 @@ import {ReportLoader, KalturaModerationFlag} from './providers';
 import {ErrorIcon} from './components/icons/error-icon';
 import {SuccessIcon} from './components/icons/success-icon';
 import {ModerationEvent} from './event';
+
+export const pluginName: string = 'playkit-js-moderation';
 // @ts-ignore
 import {FakeEvent} from '@playkit-js/playkit-js';
-import { pluginName } from "./index";
 
 const {ReservedPresetAreas, ReservedPresetNames} = ui;
 const {Text} = ui.preacti18n;

--- a/src/moderation-plugin.tsx
+++ b/src/moderation-plugin.tsx
@@ -201,6 +201,7 @@ export class ModerationPlugin extends KalturaPlayer.core.BasePlugin {
         // @ts-ignore
         displayName: 'Moderation',
         ariaLabel: 'Moderation',
+        order: 90,
         component: () => <PluginButton setRef={this._setPluginButtonRef} />,
         svgIcon: {path: icons.PLUGIN_ICON, viewBox: `0 0 ${icons.BigSize} ${icons.BigSize}`},
         onClick: this._toggleOverlay


### PR DESCRIPTION
### Description of the Changes


**fix: Wrong and inconsistent order of plugins**

**fix: Plugins buttons sometimes display with the wrong icon**

**solves: [FEC-13517](https://kaltura.atlassian.net/browse/FEC-13517) [FEC-13517](https://kaltura.atlassian.net/browse/FEC-13517)**

[FEC-13517]: https://kaltura.atlassian.net/browse/FEC-13517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FEC-13517]: https://kaltura.atlassian.net/browse/FEC-13517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

#### Related Prs
https://github.com/kaltura/playkit-js-ui-managers/pull/51
https://github.com/kaltura/playkit-js-transcript/pull/175
https://github.com/kaltura/playkit-js-share/pull/38
https://github.com/kaltura/playkit-js-playlist/pull/53
https://github.com/kaltura/playkit-js-related/pull/61
https://github.com/kaltura/playkit-js-navigation/pull/348
https://github.com/kaltura/playkit-js-info/pull/90
https://github.com/kaltura/playkit-js-downloads/pull/39
https://github.com/kaltura/playkit-js-qna/pull/334