### PR TITLE
fix(ADA-469): 'Choose a reason for reporting this content’ is not marked as required.

### DIFF
--- a/translations/en.i18n.json
+++ b/translations/en.i18n.json
@@ -11,7 +11,7 @@
       "Spam / Commercials": "Spam / Commercials",
       "close": "Close",
       "report_placeholder": "Describe what you saw...",
-      "default_content_type": "Choose a reason for reporting this content",
+      "default_content_type": "Choose a reason for reporting this content (required)",
       "report_title": "What’s wrong with this content?"
     }
   }


### PR DESCRIPTION
Added the word "required" to "Choose a reason to report this content" to indicate for visual users that this is a required field.

Solves [ADA-469](https://kaltura.atlassian.net/browse/ADA-469)

[ADA-469]: https://kaltura.atlassian.net/browse/ADA-469?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ