### PR TITLE
fix(ADA-766): “Expanded” is not announced when expanding 'Choose a reason for reporting this content' toggle button.

### DIFF
--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -106,7 +106,7 @@ export class Popover extends Component<PopoverProps> {
         <div
           className="popover-anchor-container"
           ref={node => {
-            if (node != null){
+            if (node){
               this._controlElementRef = node;
             }
           }}>

--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -3,6 +3,7 @@ import {A11yWrapper, OnClickEvent} from '@playkit-js/common/dist/hoc/a11y-wrappe
 import * as styles from './popover.scss';
 
 const {ESC, TAB} = KalturaPlayer.ui.utils.KeyMap;
+const {withEventManager} = KalturaPlayer.ui.Event;
 
 export interface PopoverMenuItem {
   label?: string;
@@ -14,9 +15,10 @@ interface PopoverProps {
   children: VNode;
   setExpandedState: (open: boolean, callback?: () => void) => void;
   open: boolean;
+  eventManager?: any;
 }
 
-
+@withEventManager
 export class Popover extends Component<PopoverProps> {
   private _controlElementRef: HTMLDivElement | null = null;
   private _popoverElementRef: HTMLDivElement | null = null;
@@ -35,7 +37,9 @@ export class Popover extends Component<PopoverProps> {
   };
 
   private _handleKeyboardEvent = (event: KeyboardEvent) => {
-    if (event.keyCode === ESC || !this._popoverElementRef?.contains(event.target as Node | null)) {
+    if (event.keyCode === ESC || (!this._popoverElementRef?.contains(event.target as Node | null)
+        && !this._controlElementRef?.contains(event.target as Node | null))) {
+
       this._closePopover();
     }
   };
@@ -60,7 +64,11 @@ export class Popover extends Component<PopoverProps> {
     this.props.setExpandedState(true, () => {
       this._addListeners();
       if (byKeyboard) {
-        this._getOptionRef(0)?.focus();
+        this.props.eventManager?.listen(this._controlElementRef, 'keydown', (event: KeyboardEvent) => {
+          if (event.keyCode === TAB){
+            this._getOptionRef(-1)?.focus();
+          }
+        })
       }
     });
   };
@@ -98,7 +106,9 @@ export class Popover extends Component<PopoverProps> {
         <div
           className="popover-anchor-container"
           ref={node => {
-            this._controlElementRef = node;
+            if (node != null){
+              this._controlElementRef = node;
+            }
           }}>
           <A11yWrapper onClick={this._togglePopover}>{props.children}</A11yWrapper>;
         </div>


### PR DESCRIPTION
Issue:
When open the dropdown for 'Choose a reason for reporting this content' the screen reader doesn't announce "expanded"

Solution:
Leave the focus on the button so screen reader will announce the state again (instead of moving the focus automatically to the first item) and handle the next tab press to move the focus to the first item in the dropdown .

Solves [ADA-766](https://kaltura.atlassian.net/browse/ADA-766)

[ADA-766]: https://kaltura.atlassian.net/browse/ADA-766?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ