### PR TITLE
ADA-1194 - Add padding to title and subtitle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### 3.2.18 (2024-06-16)
+
 ### 3.2.17 (2024-05-19)
 
 ### 3.2.16 (2024-03-14)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### 3.2.19 (2024-06-30)
+
 ### 3.2.18 (2024-06-16)
 
 ### 3.2.17 (2024-05-19)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playkit-js/moderation",
-  "version": "3.2.17",
+  "version": "3.2.18",
   "main": "dist/playkit-moderation.js",
   "private": false,
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playkit-js/moderation",
-  "version": "3.2.18",
+  "version": "3.2.19",
   "main": "dist/playkit-moderation.js",
   "private": false,
   "bugs": {
@@ -80,7 +80,7 @@
   "kaltura": {
     "name": "playkit-js-moderation",
     "dependencies": {
-      "playkit-ui-managers": "1.5.4"
+      "playkit-ui-managers": "1.5.6"
     }
   }
 }

--- a/src/components/moderation/moderation.scss
+++ b/src/components/moderation/moderation.scss
@@ -38,6 +38,7 @@
       font-weight: 700;
       text-align: left;
       line-height: 32px;
+      padding-right: 44px;
     }
     .selectTitle {
       font-size: 14px;
@@ -45,6 +46,7 @@
       font-weight: 700;
       text-align: left;
       margin-top: 24px;
+      padding-right: 44px;
     }
     .subtitle {
       margin-top: 16px;


### PR DESCRIPTION
For Zoom 200% + the Title and subtitle of this modal was overlapping with the X Close button. I've used a padding-right of 44px that solved the issue