### PR TITLE
ADA-1194 - Add padding to title and subtitle

### DIFF
--- a/src/components/moderation/moderation.scss
+++ b/src/components/moderation/moderation.scss
@@ -38,6 +38,7 @@
       font-weight: 700;
       text-align: left;
       line-height: 32px;
+      padding-right: 44px;
     }
     .selectTitle {
       font-size: 14px;
@@ -45,6 +46,7 @@
       font-weight: 700;
       text-align: left;
       margin-top: 24px;
+      padding-right: 44px;
     }
     .subtitle {
       margin-top: 16px;


### PR DESCRIPTION
For Zoom 200% + the Title and subtitle of this modal was overlapping with the X Close button. I've used a padding-right of 44px that solved the issue
Related to https://github.com/kaltura/playkit-js-moderation/pull/85