### PR TITLE
fix(ADA-1734): Continues ADA-1500, Added Localizer+Text+Translates

### DIFF
--- a/src/moderation-plugin.tsx
+++ b/src/moderation-plugin.tsx
@@ -16,7 +16,7 @@ export const pluginName: string = 'playkit-js-moderation';
 import {FakeEvent} from '@playkit-js/playkit-js';
 
 const {ReservedPresetAreas, ReservedPresetNames} = ui;
-const {Text, Localizer} = ui.preacti18n;
+const {Text} = ui.preacti18n;
 
 interface ModerationPluginConfig {
   reportLength: number;
@@ -197,14 +197,7 @@ export class ModerationPlugin extends KalturaPlayer.core.BasePlugin {
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
         displayName: 'Moderation',
-        ariaLabel: () => {
-          const textJSX = (
-            <Localizer>
-              <Text id="moderation.moderation">Moderation</Text>
-            </Localizer>
-          );
-          return textJSX
-        },
+        ariaLabel: <Text id="moderation.moderation">Moderation</Text>,
         order: 90,
         component: () => (<PluginButton setRef={this._setPluginButtonRef} />) as any,
         svgIcon: {path: icons.PLUGIN_ICON, viewBox: `0 0 ${icons.BigSize} ${icons.BigSize}`},

--- a/src/moderation-plugin.tsx
+++ b/src/moderation-plugin.tsx
@@ -16,7 +16,7 @@ export const pluginName: string = 'playkit-js-moderation';
 import {FakeEvent} from '@playkit-js/playkit-js';
 
 const {ReservedPresetAreas, ReservedPresetNames} = ui;
-const {Text} = ui.preacti18n;
+const {Text, Localizer} = ui.preacti18n;
 
 interface ModerationPluginConfig {
   reportLength: number;
@@ -197,7 +197,14 @@ export class ModerationPlugin extends KalturaPlayer.core.BasePlugin {
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
         displayName: 'Moderation',
-        ariaLabel: 'Moderation',
+        ariaLabel: () => {
+          const textJSX = (
+            <Localizer>
+              <Text id="moderation.moderation">Moderation</Text>
+            </Localizer>
+          );
+          return textJSX
+        },
         order: 90,
         component: () => (<PluginButton setRef={this._setPluginButtonRef} />) as any,
         svgIcon: {path: icons.PLUGIN_ICON, viewBox: `0 0 ${icons.BigSize} ${icons.BigSize}`},

--- a/translations/en.i18n.json
+++ b/translations/en.i18n.json
@@ -1,6 +1,7 @@
 {
   "en": {
     "moderation": {
+      "moderation": "Moderation",
       "report_button": "Report",
       "report_content": "Report Content",
       "send_success": "The report was sent successfully",


### PR DESCRIPTION
**With:**
https://github.com/kaltura/playkit-js-ui-managers/pull/64

**Issue:**:
Previous JSX was not translated when loaded in the ui-managers
This plugin had no translates and that's why it was not rendered [Object object]. 
Now that we can support translates for all plugins, I considered to add it for moderation as well.

**Fix**:
Used Text component instead of plain text for translation