### PR TITLE
fix(SUP-45439): Missing/Non-Accurate German Translations on the V7 Player

### DIFF
--- a/translations/de.i18n.json
+++ b/translations/de.i18n.json
@@ -1,9 +1,11 @@
 {
   "de": {
     "moderation": {
-      "report_button": "Bericht",
+      "report_button": "Senden",
+      "report_content": "Melden",
       "close": "Schließen",
       "report_placeholder": "Beschreiben Sie, was Sie gesehen haben...",
+      "default_content_type": "Bitte auswählen",
       "report_select_title": "Wählen Sie einen Grund, weswegen Sie diesen Inhalt melden",
       "report_title": "Was stimmt mit diesem Inhalt nicht?"
     }


### PR DESCRIPTION

Change and add German translations 

solves [SUP-45439](https://kaltura.atlassian.net/browse/SUP-45439)

[SUP-45439]: https://kaltura.atlassian.net/browse/SUP-45439?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ