### PR TITLE
fix(ADA-1805): Continues ADA-1734 adding proper translated label for the moderation plugin

### DIFF
--- a/src/moderation-plugin.tsx
+++ b/src/moderation-plugin.tsx
@@ -196,8 +196,8 @@ export class ModerationPlugin extends KalturaPlayer.core.BasePlugin {
       this._pluginIcon = this.upperBarManager!.add({
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
-        displayName: 'Moderation',
-        ariaLabel: 'Moderation',
+        displayName: 'Report Content',
+        ariaLabel: <Text id="moderation.report_content">Report Content</Text>,
         order: 90,
         component: () => (<PluginButton setRef={this._setPluginButtonRef} />) as any,
         svgIcon: {path: icons.PLUGIN_ICON, viewBox: `0 0 ${icons.BigSize} ${icons.BigSize}`},


### PR DESCRIPTION
Related to: https://github.com/kaltura/playkit-js-moderation/pull/95