### PR TITLE
fix(ADA-1736): Tooltip strict position

### DIFF
--- a/src/components/plugin-button/plugin-button.tsx
+++ b/src/components/plugin-button/plugin-button.tsx
@@ -17,7 +17,7 @@ interface PluginButtonProps {
 
 export const PluginButton = withText(translates)(({label, setRef}: PluginButtonProps) => {
   return (
-    <Tooltip label={label} type="bottom">
+    <Tooltip label={label} type="bottom-left" strictPosition={true}>
         <button type="button" aria-label={label} className={ui.style.upperBarIcon} data-testid="moderationPluginButton" ref={setRef}>
           <Icon
             id={pluginName}


### PR DESCRIPTION
This solves https://kaltura.atlassian.net/browse/ADA-1736. 
It sets the Tooltip position to always be bottom-left.